### PR TITLE
Add public/private note toggling

### DIFF
--- a/components/note-header.tsx
+++ b/components/note-header.tsx
@@ -59,12 +59,19 @@ export default function NoteHeader({
       <div className="px-2 bg-[#1c1c1c] mb-4 relative">
         <div className="flex justify-center items-center">
           <p className="text-gray-400 text-xs">{formattedDate}</p>
-          {!note.public && (
-            <Badge className="text-xs justify-center items-center ml-2">
-              <Lock className="w-3 h-3 mr-1" />
-              Private
-            </Badge>
-          )}
+          <Badge
+            onClick={() => canEdit && saveNote({ public: !note.public })}
+            variant={note.public ? "public" : "private"}
+            className="text-xs justify-center items-center ml-2 cursor-pointer"
+          >
+            {note.public ? (
+              <>Public</>
+            ) : (
+              <>
+                <Lock className="w-3 h-3 mr-1" /> Private
+              </>
+            )}
+          </Badge>
         </div>
         <div className="flex items-center relative">
           {canEdit && !note.public && !isMobile ? (

--- a/components/note-item.tsx
+++ b/components/note-item.tsx
@@ -11,6 +11,7 @@ import {
 } from "./ui/context-menu";
 import { Note } from '@/lib/types';
 import { Dispatch, SetStateAction } from "react";
+import { Badge } from "./ui/badge";
 
 function previewContent(content: string): string {
   return content
@@ -109,8 +110,14 @@ export function NoteItem({
       onClick={handleNoteClick}
     >
       <Link href={`/${item.slug || ""}`} prefetch={true} className="block py-2">
-        <h2 className="text-sm font-bold pl-4 pr-4 break-words">
+        <h2 className="text-sm font-bold pl-4 pr-4 break-words flex items-center">
           {item.emoji} {item.title}
+          <Badge
+            variant={item.public ? "public" : "private"}
+            className="ml-2 px-2 py-0.5"
+          >
+            {item.public ? "Public" : "Private"}
+          </Badge>
         </h2>
         <p
           className={`text-xs pl-4 pr-4 overflow-hidden text-ellipsis whitespace-nowrap ${

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -50,6 +50,13 @@ export default function Note({ note: initialNote }: { note: any }) {
                 content_arg: updatedNote.content,
               });
             }
+            if ('public' in updates) {
+              await supabase.rpc("update_note_public", {
+                uuid_arg: note.id,
+                session_arg: sessionId,
+                public_arg: updatedNote.public,
+              });
+            }
           }
 
           await fetch("/revalidate", {

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -15,6 +15,10 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
+        private:
+          "border-transparent bg-yellow-500 text-black hover:bg-yellow-500/80",
+        public:
+          "border-transparent bg-green-500 text-white hover:bg-green-500/80",
       },
     },
     defaultVariants: {

--- a/supabase/migrations/20240711120000_add_update_note_public.sql
+++ b/supabase/migrations/20240711120000_add_update_note_public.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION public.update_note_public(
+    uuid_arg uuid,
+    session_arg uuid,
+    public_arg boolean
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER AS $$
+BEGIN
+    UPDATE public.notes
+    SET public = public_arg
+    WHERE id = uuid_arg AND session_id = session_arg;
+END;
+$$;


### PR DESCRIPTION
## Summary
- allow toggling note visibility between private and public
- show a colored badge for each note in lists and the note header
- support updating the `public` field via Supabase RPC

## Testing
- `npm run lint` *(fails: `next` not found)*